### PR TITLE
Support for SSP v1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/1.17/simplesamlphp-changelog)
+
+### Changed
+
+- Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
+- Comply to [PSR-1: Basic Coding Standard](https://www.php-fig.org/psr/psr-1/) guidelines
+- Comply to [PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/) guidelines
+- Apply modern array syntax to comply with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-1.17)
+
 ## [v1.0.1] - 2020-12-01
+
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
 
 ### Fixed
 
 - Fix intersection bug of `$allowedAttributes` and `$metadataAllowedAttributes` arrays
 
 ## [v1.0.0] - 2019-09-17
+
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # simplesamlphp-module-attributelimit
 
-A SimpleSAMLphp authentication processing filter for whitelisting which attributes the SimpleSAMLphp SP will allow to pass on the final service.
+A SimpleSAMLphp authentication processing filter for whitelisting which attributes the SimpleSAMLphp IdP will allow to pass on the final service.
 
 ## DynamicAttributeLimit
 
@@ -8,36 +8,46 @@ The `attributelimit:DynamicAttributeLimit` is a SimpleSAMLphp authentication pro
 
 ### Configuration
 
-To configure the module you need to define the name of the allowed attribute(s) as value(s) inside the array which the module has been defined.
+The following authproc filter configuration options are supported:
+
+- `allowedAttributes`: Optional, an array of strings that contains the attribute names that the module will allow to pass on. Also, there is support to filter the attribute values usign regex.
+- `eppnFromIdp`: Optional, an array of strings that contains the entityID of the IdPs that release `eduPersonPrincipalName`.
+- `eppnToSp`: Optional, an array of strings that contains the entityID of the SPs that request for `eduPersonPrincipalName`.
 
 ### Example configuration
 
 ```php
 authproc = array(
     ...
-    92 => array(
-        'class' => 'core:DynamicAttributeLimit',
-        'distinguishedName',
-        'displayName',
-        'eduPersonAssurance',
-        'eduPersonScopedAffiliation',
-        'eduPersonEntitlement',
-        'sn',
-        'mail',
-        'givenName',
-        'eduPersonUniqueId',
-        'uid',
-        'schacHomeOrganization',
-    ),
+    XX => [
+        'class' => 'attributelimit:DynamicAttributeLimit',
+        'allowedAttributes' => [
+            'displayName',
+            'eduPersonEntitlement' => [
+                'regex' => true,
+                '/^urn:mace:egi.eu:/i',
+            ],
+        ],
+        'eppnFromIdp' => [
+            'idpEntityId01',
+            'idpEntityId02',
+        ],
+        'eppnToSp' => [
+            'spEntityId01',
+            'spEntityId02',
+            'spEntityId03',
+        ],
+    ],
+
 ```
 
 ## Compatibility matrix
 
 This table matches the module version with the supported SimpleSAMLphp version.
 
-| Module |  SimpleSAMLphp |
-|:------:|:--------------:|
-| v1.0   | v1.14          |
+| Module | SimpleSAMLphp |
+| :----: | :-----------: |
+|  v1.0  |     v1.14     |
 
 ## License
 

--- a/lib/Auth/Process/DynamicAttributeLimit.php
+++ b/lib/Auth/Process/DynamicAttributeLimit.php
@@ -50,7 +50,7 @@ class DynamicAttributeLimit extends \SimpleSAML\Auth\ProcessingFilter
     private $eppnToSp = array();
 
     /**
-     * Assosiative array with the mappings of attribute names.
+     * Associative array with the mappings of attribute names.
      */
     private $map = array();
 
@@ -158,8 +158,8 @@ class DynamicAttributeLimit extends \SimpleSAML\Auth\ProcessingFilter
                     }
                     $metadataAllowedAttributes[] = $this->map[$name];
                 } else {
-                    foreach ($this->map[$name] as $to_map) {
-                        $metadataAllowedAttributes[] = $to_map;
+                    foreach ($this->map[$name] as $toMap) {
+                        $metadataAllowedAttributes[] = $toMap;
                     }
                     if (!$this->duplicate && !in_array($name, $this->map[$name], TRUE)) {
                         unset($metadataAllowedAttributes[$key]);

--- a/lib/Auth/Process/DynamicAttributeLimit.php
+++ b/lib/Auth/Process/DynamicAttributeLimit.php
@@ -237,6 +237,8 @@ class DynamicAttributeLimit extends ProcessingFilter
             throw new Exception('Could not find attributemap file: ' . $filePath);
         }
 
+        // Reminder: Don't change the case of this variable (as described in PSR-12)
+        // this is how the array is defined in the attribute map file
         $attributemap = null;
         include($filePath);
         if (!is_array($attributemap)) {

--- a/lib/Auth/Process/DynamicAttributeLimit.php
+++ b/lib/Auth/Process/DynamicAttributeLimit.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\attributelimit\Auth\Process;
+
 /**
  * A filter for limiting which attributes are passed on.
  * 
@@ -29,7 +31,7 @@
  * @author Nick Evangelou <nikos.ev@hotmail.com>
  * @package SimpleSAMLphp
  */
-class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAML_Auth_ProcessingFilter
+class DynamicAttributeLimit extends \SimpleSAML\Auth\ProcessingFilter
 {
 
     /**
@@ -59,7 +61,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
      *
      * @param array $config  Configuration information about this filter.
      * @param mixed $reserved  For future use
-     * @throws SimpleSAML_Error_Exception If invalid configuration is found.
+     * @throws SimpleSAML\Error\Exception If invalid configuration is found.
      */
     public function __construct($config, $reserved)
     {
@@ -69,24 +71,24 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
 
         if (array_key_exists('allowedAttributes', $config)) {
             if (!is_array($config['allowedAttributes'])) {
-                SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'allowedAttributes' not an array");
-                throw new SimpleSAML_Error_Exception(
+                SimpleSAML\Logger::error("[attrauthcomanage] Configuration error: 'allowedAttributes' not an array");
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'allowedAttributes' not an array");
             }
             $this->allowedAttributes = $config['allowedAttributes'];
         }
         if (array_key_exists('eppnFromIdp', $config)) {
             if (!is_array($config['eppnFromIdp'])) {
-                SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'eppnFromIdp' not an array");
-                throw new SimpleSAML_Error_Exception(
+                SimpleSAML\Logger::error("[attrauthcomanage] Configuration error: 'eppnFromIdp' not an array");
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'eppnFromIdp' not an array");
             }
             $this->eppnFromIdp = $config['eppnFromIdp'];
         }
         if (array_key_exists('eppnToSp', $config)) {
             if (!is_array($config['eppnToSp'])) {
-                SimpleSAML_Logger::error("[attrauthcomanage] Configuration error: 'eppnToSp' not an array");
-                throw new SimpleSAML_Error_Exception(
+                SimpleSAML\Logger::error("[attrauthcomanage] Configuration error: 'eppnToSp' not an array");
+                throw new SimpleSAML\Error\Exception(
                     "attrauthcomanage configuration error: 'eppnToSp' not an array");
             }
             $this->eppnToSp = $config['eppnToSp'];
@@ -121,7 +123,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
      * Removes all attributes which aren't one of the allowed attributes.
      *
      * @param array &$request  The current request
-     * @throws SimpleSAML_Error_Exception If invalid configuration is found.
+     * @throws SimpleSAML\Error\Exception If invalid configuration is found.
      */
     public function process(&$request)
     {
@@ -129,7 +131,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
         assert('array_key_exists("Attributes", $request)');
 
         if (isset($request['SPMetadata']['entityid']) && in_array($request['SPMetadata']['entityid'], $this->eppnToSp)) {
-            SimpleSAML_Logger::debug(
+            SimpleSAML\Logger::debug(
                 "[DynamicAttributeLimit] process: SP="
                     . var_export($request['SPMetadata']['entityid'], true)
             );
@@ -139,7 +141,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
             }
             if (!empty(array_intersect($idpEntityId, $this->eppnFromIdp))) {
                 $this->allowedAttributes[] = "eduPersonPrincipalName";
-                SimpleSAML_Logger::debug(
+                SimpleSAML\Logger::debug(
                     "[DynamicAttributeLimit] process: allowed attrs= "
                         . var_export($this->allowedAttributes, true)
                 );
@@ -151,7 +153,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
             if (array_key_exists($name, $this->map)) {
                 if (!is_array($this->map[$name])) {
                     if (!$this->duplicate) {
-                        SimpleSAML_Logger::debug("[DynamicAttributeLimit] unset mdAllowedAttributes[" . var_export($name, true) . "]");
+                        SimpleSAML\Logger::debug("[DynamicAttributeLimit] unset mdAllowedAttributes[" . var_export($name, true) . "]");
                         unset($metadataAllowedAttributes[$key]);
                     }
                     $metadataAllowedAttributes[] = $this->map[$name];
@@ -165,9 +167,9 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
                 }
             }
         }
-        SimpleSAML_Logger::debug("[DynamicAttributeLimit] mdAllowedAttributes=" . var_export($metadataAllowedAttributes, true));
+        SimpleSAML\Logger::debug("[DynamicAttributeLimit] mdAllowedAttributes=" . var_export($metadataAllowedAttributes, true));
         if (empty($this->allowedAttributes) && empty($metadataAllowedAttributes)) {
-            SimpleSAML_Logger::debug("[DynamicAttributeLimit] No limit on attributes");
+            SimpleSAML\Logger::debug("[DynamicAttributeLimit] No limit on attributes");
             return; /* No limit on attributes. */
         }
         if (!empty($this->allowedAttributes)) {
@@ -180,7 +182,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
         } else {
             $allowedAttributes = $metadataAllowedAttributes;
         }
-        SimpleSAML_Logger::debug("[DynamicAttributeLimit] allowedAttributes=" . var_export($allowedAttributes, true));
+        SimpleSAML\Logger::debug("[DynamicAttributeLimit] allowedAttributes=" . var_export($allowedAttributes, true));
 
         $attributes = &$request['Attributes'];
 
@@ -190,7 +192,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
                 if (array_key_exists($name, $allowedAttributes)) {
                     // but it is an index of the array
                     if (!is_array($allowedAttributes[$name])) {
-                        throw new SimpleSAML_Error_Exception('AttributeLimit: Values for ' . var_export($name, TRUE) . ' must be specified in an array.');
+                        throw new SimpleSAML\Error\Exception('AttributeLimit: Values for ' . var_export($name, TRUE) . ' must be specified in an array.');
                     }
                     $attributes[$name] = $this->filterAttributeValues($attributes[$name], $allowedAttributes[$name]);
                     if (!empty($attributes[$name])) {
@@ -209,7 +211,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
      */
     private function loadMapFile($fileName)
     {
-        $config = SimpleSAML_Configuration::getInstance();
+        $config = SimpleSAML\Configuration::getInstance();
         $filePath = $config->getPathValue('attributenamemapdir', 'attributemap/') . $fileName . '.php';
 
         if (!file_exists($filePath)) {
@@ -249,7 +251,7 @@ class sspmod_attributelimit_Auth_Process_DynamicAttributeLimit extends SimpleSAM
                     // prevents us from testing with invalid regex.
                     $regexResult = @preg_match($pattern, $attributeValue);
                     if ($regexResult === false) {
-                        SimpleSAML_Logger::warning("Error processing regex '$pattern' on value '$attributeValue'");
+                        SimpleSAML\Logger::warning("Error processing regex '$pattern' on value '$attributeValue'");
                         break;
                     } elseif ($regexResult === 1) {
                         $matchedValues[] = $attributeValue;

--- a/lib/Auth/Process/DynamicAttributeLimit.php
+++ b/lib/Auth/Process/DynamicAttributeLimit.php
@@ -11,25 +11,25 @@ use SimpleSAML\Logger;
  * A filter for limiting which attributes are passed on.
  *
  * Example config
- * XX => array(
+ * XX => [
  *     'class' => 'attributelimit:DynamicAttributeLimit',
- *     'allowedAttributes' => array(
+ *     'allowedAttributes' => [
  *         'displayName',
- *         'eduPersonEntitlement' => array(
+ *         'eduPersonEntitlement' => [
  *             'regex' => true,
  *             '/^urn:mace:egi.eu:/i',
- *         ),
- *     ),
- *     'eppnFromIdp' => array(
+ *         ],
+ *     ],
+ *     'eppnFromIdp' => [
  *         'idpEntityId01',
  *         'idpEntityId02',
- *     ),
- *     'eppnToSp' => array(
+ *     ],
+ *     'eppnToSp' => [
  *         'spEntityId01',
  *         'spEntityId02',
  *         'spEntityId03',
- *     ),
- * ),
+ *     ],
+ * ],
  *
  * @author Olav Morken, UNINETT AS.
  * @author Nicolas Liampotis <nicolas.liampotis@gmail.com>
@@ -42,22 +42,22 @@ class DynamicAttributeLimit extends ProcessingFilter
     /**
      * List of attributes which this filter will allow through.
      */
-    private $allowedAttributes = array();
+    private $allowedAttributes = [];
 
     /**
      * List of IdP entityIDs that release ePPN
      */
-    private $eppnFromIdp = array();
+    private $eppnFromIdp = [];
 
     /**
      * List of SP entityIDs that require ePPN
      */
-    private $eppnToSp = array();
+    private $eppnToSp = [];
 
     /**
      * Associative array with the mappings of attribute names.
      */
-    private $map = array();
+    private $map = [];
 
     private $duplicate = false;
 
@@ -121,7 +121,7 @@ class DynamicAttributeLimit extends ProcessingFilter
             // IdP Config
             return $request['Source']['attributes'];
         }
-        return array();
+        return [];
     }
 
 
@@ -146,7 +146,7 @@ class DynamicAttributeLimit extends ProcessingFilter
                 "[DynamicAttributeLimit] process: SP="
                 . var_export($request['SPMetadata']['entityid'], true)
             );
-            $idpEntityId = array();
+            $idpEntityId = [];
             if (!empty($request['Attributes']['idpEntityId'])) {
                 $idpEntityId = $request['Attributes']['idpEntityId'];
             }
@@ -158,7 +158,7 @@ class DynamicAttributeLimit extends ProcessingFilter
                 );
             }
         }
-        $metadataAllowedAttributes = array_merge(array(), self::getSPIdPAllowed($request));
+        $metadataAllowedAttributes = array_merge([], self::getSPIdPAllowed($request));
         $this->loadMapFile('oid2name');
         foreach ($metadataAllowedAttributes as $key => $name) {
             if (array_key_exists($name, $this->map)) {


### PR DESCRIPTION
- Comply to [PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/) guidelines
- Comply to [PSR-1: Basic Coding Standard](https://www.php-fig.org/psr/psr-1/) guidelines
- Comply to [PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/) guidelines
- Apply modern array syntax to comply with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/stable/simplesamlphp-upgrade-notes-1.17)